### PR TITLE
JSB-DOM-Events-1: addEventListener, delegation, preventDefault, basic form handling

### DIFF
--- a/exercises/jsb/dom-events-forms/dom-events-forms.html
+++ b/exercises/jsb/dom-events-forms/dom-events-forms.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="uk">
+<head>
+  <meta charset="utf-8" />
+  <title>DOM Tasks — Events & Forms</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    :root {
+      --bg: #ffffff;
+      --fg: #222;
+      --muted: #666;
+      --primary: #0b5fff;
+      --active-bg: #e7f1ff;
+      --active-outline: #8cb8ff;
+      --error: #c62828;
+    }
+    html, body { height: 100%; }
+    body {
+      margin: 0;
+      padding: 24px;
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+      color: var(--fg);
+      background: var(--bg);
+    }
+    h1 { margin: 0 0 12px; font-size: 22px; }
+    .row { display: flex; gap: 8px; align-items: center; margin: 12px 0; flex-wrap: wrap; }
+    .row .spacer { flex: 1 1 auto; }
+    a { color: var(--primary); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    input[type="text"] {
+      padding: 8px 10px;
+      border: 1px solid #ccc;
+      border-radius: 8px;
+      min-width: 240px;
+      font-size: 14px;
+      outline: none;
+    }
+    input[type="text"]:focus { border-color: var(--primary); box-shadow: 0 0 0 3px rgba(11,95,255,0.15); }
+    button {
+      padding: 8px 12px;
+      border: 1px solid #444;
+      border-radius: 8px;
+      background: #fff;
+      cursor: pointer;
+      font-size: 14px;
+    }
+    button:hover { background: #f5f5f5; }
+    ul#items {
+      margin: 12px 0 0;
+      padding-left: 20px;
+    }
+    ul#items li {
+      list-style: disc;
+      padding: 6px 8px;
+      border-radius: 6px;
+      cursor: pointer;
+      user-select: none;
+    }
+    ul#items li.active {
+      background: var(--active-bg);
+      outline: 1px solid var(--active-outline);
+    }
+    .error {
+      display: inline-block;
+      min-height: 1.2em;
+      color: var(--error);
+      margin-left: 8px;
+      font-size: 14px;
+      visibility: hidden;
+    }
+    .error.active { visibility: visible; }
+    .hint {
+      color: var(--muted);
+      font-size: 13px;
+      margin-top: 6px;
+    }
+    .panel {
+      display: grid;
+      gap: 10px;
+      align-items: start;
+      grid-template-columns: 1fr auto auto;
+    }
+  </style>
+</head>
+<body>
+
+  <h1 id="title">Items (3)</h1>
+
+  <div class="row">
+    <a class="confirm-add" href="https://example.com/add">Go to add</a>
+    <span class="spacer"></span>
+    <button id="clearBtn" type="button">Clear</button>
+  </div>
+
+  <form id="addItem" class="panel" novalidate>
+    <input
+      id="itemInput"
+      type="text"
+      name="item"
+      placeholder="Новий пункт…"
+      minlength="3"
+      autocomplete="off"
+      aria-describedby="error"
+      required
+    />
+    <button type="submit">Add</button>
+    <span id="error" class="error" aria-live="polite"></span>
+  </form>
+
+  <ul id="items" aria-label="Список пунктів">
+    <li>Alpha</li>
+    <li>Beta</li>
+    <li>Gamma</li>
+  </ul>
+
+  <p class="hint">
+  </p>
+
+  <script src="./dom-events-forms.js"></script>
+</body>
+</html>

--- a/exercises/jsb/dom-events-forms/dom-events-forms.js
+++ b/exercises/jsb/dom-events-forms/dom-events-forms.js
@@ -1,0 +1,79 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const listEl   = document.getElementById('items');
+  const linkEl   = document.querySelector('.confirm-add');
+  const formEl   = document.getElementById('addItem');
+  const inputEl  = document.getElementById('itemInput');
+  const errorEl  = document.getElementById('error');
+
+  function showError(msg) {
+    errorEl.textContent = msg || '';
+    errorEl.classList.toggle('active', !!msg);
+  }
+
+  
+  listEl.addEventListener('click', (e) => {
+    const li = e.target.closest('li');
+    if (!li || !listEl.contains(li)) return;
+
+    const prev = listEl.querySelector('li.active');
+    if (prev && prev !== li) prev.classList.remove('active');
+    li.classList.toggle('active');
+  });
+
+  if (linkEl) {
+    linkEl.addEventListener('click', (e) => {
+      const ok = window.confirm('Перейти за посиланням?');
+      if (!ok) {
+        e.preventDefault();
+      }
+    });
+  }
+
+  const normalizedValue = () => inputEl.value.trim();
+
+  function isValidValue(v) {
+    return v.length >= 3;
+  }
+
+  inputEl.addEventListener('input', () => {
+    const v = normalizedValue();
+    if (v.length === 0) {
+      showError('Поле не може бути порожнім.');
+    } else if (!isValidValue(v)) {
+      showError(`Мінімум 3 символи (зараз: ${v.length}).`);
+    } else {
+      showError('');
+    }
+  });
+
+  formEl.addEventListener('submit', (e) => {
+    e.preventDefault();
+
+    const v = normalizedValue();
+
+    if (v.length === 0) {
+      showError('Поле не може бути порожнім.');
+      inputEl.focus();
+      return;
+    }
+    if (!isValidValue(v)) {
+      showError('Значення закоротке (мінімум 3 символи).');
+      inputEl.focus();
+      return;
+    }
+
+    const li = document.createElement('li');
+    li.textContent = v;
+
+    const prev = listEl.querySelector('li.active');
+    if (prev) prev.classList.remove('active');
+    li.classList.add('active');
+
+    listEl.appendChild(li);
+
+    formEl.reset();
+    showError('');
+
+    inputEl.focus();
+  });
+});

--- a/warmups/jsb/dom-events-forms/dom-events-forms.js
+++ b/warmups/jsb/dom-events-forms/dom-events-forms.js
@@ -1,0 +1,29 @@
+//Task 1 - 2
+
+/*querySelector/All should be chosen when flexible CSS selectors (classes, attributes, nesting) are needed or when it is necessary to retrieve more than just a unique id; textContent should be used to output user text in order to avoid executing or interpreting HTML and XSS injections; addEventListener allows multiple handlers, delegation, options, and easy removal of a specific listener, while element.onclick supports only one; event.preventDefault() cancels the default behavior (link navigation, form submission) and is needed for custom logic before or instead of the default action.
+
+When to use querySelector/All
+Choose querySelector/All when the selection requires CSS selectors: by class (.btn), attribute ([data-role=“nav”]), nesting (form.login input[name=“email”]), pseudo-classes, etc.; getElementById only works with a unique id and does not cover such cases.
+
+An example of a selector that cannot be reached via getElementById: ‘ul#menu > li.active a[href^=“/docs”]’ — selects links in active menu items with a specific path prefix; this requires full expressiveness of CSS selectors.
+
+textContent vs innerHTML
+textContent inserts text as-is, without parsing HTML, which prevents injections and accidental script execution; innerHTML parses the string as HTML and can open up opportunities for XSS if unverified user data gets into it.
+
+In most UI scenarios, user-provided content should be displayed as safe text, so textContent is the safe default; innerHTML should only be used for inserting*/
+
+
+//Task 3
+/*onclick vs addEventListener
+element.onclick stores only one listener: assigning a new one will overwrite the previous one; addEventListener allows you to attach multiple handlers to the same event for a single element.
+
+Removing a listener: for onclick, it is enough to reset the property (element.onclick = null), but it is impossible to have several at the same time; for addEventListener, use removeEventListener with the same callback signature, which provides precise control over the lifecycle of handlers.
+
+Flexibility of addEventListener: supports capture/bubble phases, parameters (once, passive, capture), delegation via bubbling, and same-type multiple listeners, making it a basic tool for complex interfaces.*/
+
+//Task 4
+
+/*Що робить preventDefault
+event.preventDefault() скасовує стандартну дію браузера (наприклад, перехід за посиланням, відправлення форми), дозволяючи вам виконати власну логіку перед нею або замість неї; це корисно для навігації SPA або вбудованих підтверджень.
+
+Приклади: натискання на посилання спочатку відкриває модальне підтвердження — якщо користувач погоджується, перехід виконується вручну; відправлення форми блокується для перевірки на стороні клієнта, і тільки після успішної перевірки дані надсилаються програмно або розмітка оновлюється без перезавантаження.*/


### PR DESCRIPTION
I introduced DOM event handling and basic form workflows. The warmups cover when to use addEventListener vs onclick, how to delegate events to a container, and how/why to use preventDefault for links and forms. The exercise builds a small UI: delegated list toggling, a confirmation link, and a form with client-side validation that prevents submission until inputs are valid.

What’s included

Warmups: addEventListener/removeEventListener, event delegation patterns, preventDefault for cancelable events, and simple validity checks.

Exercise: delegated click handling on a list, a confirmation link flow, and a form that trims input, shows inline errors, and appends new list items without a full page reload.

Notes

preventDefault only works on cancelable events; HTML5 validity APIs simplify client-side checks.

Use delegation to handle dynamic <li> elements efficiently.

How to test

Open the exercises page, try clicking the confirmation link and list items, and submit the form with invalid vs valid input to observe prevented submissions and inline errors.